### PR TITLE
Taking using statement out to prevent connection from closing too soon.

### DIFF
--- a/src/Database/Repository/BaseRepository.cs
+++ b/src/Database/Repository/BaseRepository.cs
@@ -1,4 +1,4 @@
-﻿using System.Data.Entity;
+using System.Data.Entity;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -6,43 +6,39 @@ namespace DEA.Database.Repository
 {
     public static class BaseRepository<TEntity> where TEntity : class
     {
+        //Must have this here otherwise the context closes too soon and won't save or get from database!
+        private static readonly DEAContext db = new DEAContext();
 
         public static async Task InsertAsync(TEntity entity)
         {
-            using (var db = new DEAContext())
-            {
+           
                 db.Set<TEntity>().Add(entity);
                 db.Entry(entity).State = EntityState.Added;
                 await db.SaveChangesAsync();
-            }
+            
         }
 
         public static async Task UpdateAsync(TEntity entity)
         {
-            using (var db = new DEAContext())
-            {
+            
                 db.Set<TEntity>().Add(entity);
                 db.Entry(entity).State = EntityState.Modified;
                 await db.SaveChangesAsync();
-            }
+            
         }
 
         public static async Task DeleteAsync(TEntity entity)
         {
-            using (var db = new DEAContext())
-            {
+            
                 db.Set<TEntity>().Remove(entity);
                 db.Entry(entity).State = EntityState.Deleted;
                 await db.SaveChangesAsync();
-            } 
+            
         }
 
         public static IQueryable<TEntity> GetAll()
         {
-            using (var db = new DEAContext())
-            {
-                return db.Set<TEntity>();
-            }   
+           return db.Set<TEntity>();
         }
 
     }


### PR DESCRIPTION
Hi John,

Needed to take out the Using statement, it is causing connection to close before some functions are done since it is using Async functions which can complete after the connection was disposed of this closing it and resulting in an error.

